### PR TITLE
[Phase 5] Discord Publisher + Publish State 전이

### DIFF
--- a/parliament/discord_registry.py
+++ b/parliament/discord_registry.py
@@ -57,6 +57,14 @@ class DiscordRegistry:
             )
         return self._profiles[discord_user_id]
 
+    def resolve_by_hermes_profile(self, hermes_profile: str) -> HermesProfile:
+        for profile in self._profiles.values():
+            if profile.hermes_profile == hermes_profile:
+                return profile
+        raise KeyError(
+            f"No profile found for hermes profile: {hermes_profile}"
+        )
+
 
 def load_registry(path: str) -> DiscordRegistry:
     raw_data = yaml.safe_load(Path(path).read_text(encoding="utf-8"))

--- a/parliament/publishers/__init__.py
+++ b/parliament/publishers/__init__.py
@@ -1,0 +1,4 @@
+from parliament.publishers.base import Publisher
+from parliament.publishers.discord import DiscordPublisher
+
+__all__ = ["Publisher", "DiscordPublisher"]

--- a/parliament/publishers/base.py
+++ b/parliament/publishers/base.py
@@ -1,0 +1,25 @@
+"""Abstract base class for publishers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from parliament.models import TurnRecord
+
+
+class Publisher(ABC):
+    """Abstract publisher that sends turns and final results to an external channel."""
+
+    @abstractmethod
+    async def send_turn(self, session_id: str, turn_record: TurnRecord) -> str | None:
+        """Send a turn record to the external channel.
+
+        Returns the published message ID, or ``None`` if skipped or failed.
+        """
+
+    @abstractmethod
+    async def send_final(self, coordinator_token: str, synthesis_result) -> str | None:
+        """Send the final synthesis result to the external channel.
+
+        Returns the published message ID, or ``None`` if failed.
+        """

--- a/parliament/publishers/discord.py
+++ b/parliament/publishers/discord.py
@@ -1,0 +1,252 @@
+"""Discord HTTP API publisher with per-profile bot tokens."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import aiohttp
+
+from parliament.discord_registry import DiscordRegistry
+from parliament.models import TurnRecord
+from parliament.publishers.base import Publisher
+from parliament.session import SessionStore
+
+
+class DiscordPublisher(Publisher):
+    """Publishes turns to Discord via HTTP API using per-profile bot tokens."""
+
+    DISCORD_API_BASE = "https://discord.com/api/v10"
+
+    def __init__(
+        self,
+        registry: DiscordRegistry,
+        store: SessionStore,
+        channel_id: str | None = None,
+    ) -> None:
+        self.registry = registry
+        self.store = store
+        self.channel_id = channel_id or registry.coordinator.get("channel_id")
+        if not self.channel_id:
+            raise ValueError("channel_id is required")
+
+    async def send_turn(self, session_id: str, turn_record: TurnRecord) -> str | None:
+        # 1. Check publish state – skip if already successfully sent
+        state = self.store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+        if state in ("sent", "sent_via_fallback"):
+            return None  # skip
+
+        # 2. Resolve profile and generate deterministic nonce
+        profile = self.registry.resolve_by_hermes_profile(turn_record.profile)
+        nonce = self.store.generate_nonce(
+            session_id, turn_record.turn_uuid, profile.discord_user_id
+        )
+
+        # 3. Mark in-flight
+        self.store.mark_turn_publish_in_flight(
+            session_id,
+            turn_record.turn_uuid,
+            nonce,
+            intended_publisher=profile.discord_user_id,
+            attempt_publisher=profile.discord_user_id,
+        )
+
+        # 4. Build request payload
+        url = f"{self.DISCORD_API_BASE}/channels/{self.channel_id}/messages"
+        headers: dict[str, str] = {
+            "Authorization": f"Bot {profile.discord_bot_token}",
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "content": turn_record.content,
+            "nonce": nonce,
+            "enforce_nonce": True,
+        }
+
+        # 5. POST with retry / fallback logic
+        return await self._post_turn(
+            url, headers, payload, session_id, turn_record, profile
+        )
+
+    async def _post_turn(
+        self,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+        session_id: str,
+        turn_record: TurnRecord,
+        profile: Any,
+    ) -> str | None:
+        max_network_attempts = 4
+        network_attempts = 0
+
+        while True:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        url, headers=headers, json=payload
+                    ) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            msg_id = data["id"]
+                            published_at = (
+                                datetime.now(timezone.utc)
+                                .isoformat()
+                                .replace("+00:00", "Z")
+                            )
+                            self.store.mark_turn_published(
+                                session_id,
+                                turn_record.turn_uuid,
+                                msg_id,
+                                published_by=profile.discord_user_id,
+                                published_at=published_at,
+                                state="sent",
+                                attempt_publisher=profile.discord_user_id,
+                            )
+                            return msg_id
+
+                        if resp.status == 429:
+                            retry_after = float(
+                                resp.headers.get("Retry-After", 1)
+                            )
+                            await asyncio.sleep(retry_after)
+                            continue
+
+                        if resp.status in (403, 401):
+                            error = f"HTTP {resp.status}: unauthorized"
+                            self.store.mark_turn_publish_fallback_pending(
+                                session_id,
+                                turn_record.turn_uuid,
+                                error,
+                                attempt_publisher=profile.discord_user_id,
+                            )
+                            return await self._fallback_post(
+                                url, payload, session_id, turn_record
+                            )
+
+                        # Other HTTP errors – retry then terminal
+                        network_attempts += 1
+                        if network_attempts < max_network_attempts:
+                            await asyncio.sleep(1)
+                            continue
+
+                        error = f"HTTP {resp.status}"
+                        self.store.mark_turn_publish_failed(
+                            session_id,
+                            turn_record.turn_uuid,
+                            error,
+                            retryable=False,
+                            attempt_publisher=profile.discord_user_id,
+                        )
+                        return None
+
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                network_attempts += 1
+                if network_attempts < max_network_attempts:
+                    await asyncio.sleep(1)
+                    continue
+
+                self.store.mark_turn_publish_failed(
+                    session_id,
+                    turn_record.turn_uuid,
+                    str(exc),
+                    retryable=True,
+                    attempt_publisher=profile.discord_user_id,
+                )
+                return None
+
+    async def _fallback_post(
+        self,
+        url: str,
+        payload: dict[str, Any],
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> str | None:
+        coord_token = self.registry.coordinator.get("bot_token")
+        if not coord_token:
+            self.store.mark_turn_publish_failed(
+                session_id,
+                turn_record.turn_uuid,
+                "No coordinator token for fallback",
+                retryable=False,
+                attempt_publisher="coordinator_fallback",
+            )
+            return None
+
+        headers: dict[str, str] = {
+            "Authorization": f"Bot {coord_token}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url, headers=headers, json=payload
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        msg_id = data["id"]
+                        published_at = (
+                            datetime.now(timezone.utc)
+                            .isoformat()
+                            .replace("+00:00", "Z")
+                        )
+                        self.store.mark_turn_published(
+                            session_id,
+                            turn_record.turn_uuid,
+                            msg_id,
+                            published_by="coordinator_fallback",
+                            published_at=published_at,
+                            state="sent_via_fallback",
+                            attempt_publisher="coordinator_fallback",
+                        )
+                        return msg_id
+                    else:
+                        error = f"Fallback HTTP {resp.status}"
+                        self.store.mark_turn_publish_failed(
+                            session_id,
+                            turn_record.turn_uuid,
+                            error,
+                            retryable=False,
+                            attempt_publisher="coordinator_fallback",
+                        )
+                        return None
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            self.store.mark_turn_publish_failed(
+                session_id,
+                turn_record.turn_uuid,
+                f"Fallback network error: {exc}",
+                retryable=False,
+                attempt_publisher="coordinator_fallback",
+            )
+            return None
+
+    async def send_final(
+        self, coordinator_token: str, synthesis_result: Any
+    ) -> str | None:
+        url = (
+            f"{self.DISCORD_API_BASE}/channels/{self.channel_id}/messages"
+        )
+        headers: dict[str, str] = {
+            "Authorization": f"Bot {coordinator_token}",
+            "Content-Type": "application/json",
+        }
+        content = (
+            synthesis_result
+            if isinstance(synthesis_result, str)
+            else str(synthesis_result)
+        )
+        payload: dict[str, Any] = {"content": content}
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url, headers=headers, json=payload
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        return data.get("id")
+                    return None
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ packages = ["parliament"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+    "aioresponses>=0.7",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/unit/test_discord_publisher.py
+++ b/tests/unit/test_discord_publisher.py
@@ -1,0 +1,321 @@
+"""Phase 5 acceptance criteria: Discord Publisher + Publish State."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from aioresponses import aioresponses
+
+from parliament.discord_registry import DiscordRegistry, HermesProfile
+from parliament.models import TurnRecord
+from parliament.publishers.discord import DiscordPublisher
+from parliament.session import SessionStore
+
+
+@pytest.fixture
+def tmp_parliament_dir(tmp_path: Path) -> Path:
+    return tmp_path / ".parliament"
+
+
+@pytest.fixture
+def store(tmp_parliament_dir: Path) -> SessionStore:
+    return SessionStore(base_dir=tmp_parliament_dir)
+
+
+@pytest.fixture
+def registry() -> DiscordRegistry:
+    profiles = {
+        "123456789": HermesProfile(
+            hermes_profile="architect-devil",
+            discord_bot_token="devil-token-123",
+            discord_user_id="123456789",
+            discord_name="Test Bot",
+        )
+    }
+    coordinator = {
+        "bot_token": "coordinator-token-456",
+        "channel_id": "999999999",
+    }
+    return DiscordRegistry(profiles=profiles, coordinator=coordinator)
+
+
+@pytest.fixture
+def publisher(registry: DiscordRegistry, store: SessionStore) -> DiscordPublisher:
+    return DiscordPublisher(registry, store)
+
+
+@pytest.fixture
+def session_id(store: SessionStore) -> str:
+    return store.create_session("topic", ["p1", "p2"], {})
+
+
+@pytest.fixture
+def turn_record() -> TurnRecord:
+    return TurnRecord(
+        turn_uuid="turn-1",
+        seq=0,
+        profile="architect-devil",
+        role="user",
+        content="Hello world",
+    )
+
+
+DISCORD_API_URL = "https://discord.com/api/v10/channels/999999999/messages"
+
+
+class TestT5ValidToken:
+    """T5-1: valid token → 200, message_id, sent state."""
+
+    async def test_send_turn_success(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                status=200,
+                payload={"id": "msg-123"},
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id == "msg-123"
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "sent"
+        )
+
+
+class TestT5UnauthorizedFallback:
+    """T5-2: 403/401 → fallback, sent_via_fallback."""
+
+    async def test_403_fallback_to_coordinator(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                status=403,
+            )
+            m.post(
+                DISCORD_API_URL,
+                status=200,
+                payload={"id": "msg-fallback"},
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id == "msg-fallback"
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "sent_via_fallback"
+        )
+
+    async def test_401_fallback_to_coordinator(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                status=401,
+            )
+            m.post(
+                DISCORD_API_URL,
+                status=200,
+                payload={"id": "msg-fallback-401"},
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id == "msg-fallback-401"
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "sent_via_fallback"
+        )
+
+
+class TestT5NetworkTimeout:
+    """T5-3: network timeout → 3 retries, failed_retryable."""
+
+    async def test_network_timeout_retries_then_failed_retryable(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                exception=asyncio.TimeoutError(),
+                repeat=4,
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id is None
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "failed_retryable"
+        )
+
+
+class TestT5RateLimit:
+    """T5-4: 429 → retry-after wait, then success."""
+
+    async def test_429_wait_then_success(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            sleep_calls.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                status=429,
+                headers={"Retry-After": "0.5"},
+            )
+            m.post(
+                DISCORD_API_URL,
+                status=200,
+                payload={"id": "msg-429-ok"},
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+
+        assert msg_id == "msg-429-ok"
+        assert sleep_calls == [0.5]
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "sent"
+        )
+
+
+class TestT5AlreadySent:
+    """T5-5: already sent → skip."""
+
+    async def test_already_sent_skips(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        store.mark_turn_published(
+            session_id,
+            turn_record.turn_uuid,
+            "msg-old",
+            "participant_bot",
+            "2026-04-21T12:00:00Z",
+            state="sent",
+            attempt_publisher="participant_bot",
+        )
+        with aioresponses() as m:
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id is None
+
+
+class TestT5AlreadySentViaFallback:
+    """T5-6: already sent_via_fallback → skip."""
+
+    async def test_already_sent_via_fallback_skips(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        store.mark_turn_published(
+            session_id,
+            turn_record.turn_uuid,
+            "msg-old",
+            "coordinator_fallback",
+            "2026-04-21T12:00:00Z",
+            state="sent_via_fallback",
+            attempt_publisher="coordinator_fallback",
+        )
+        with aioresponses() as m:
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id is None
+
+
+class TestT5FailedRetryableRetry:
+    """T5-7: failed_retryable → retry, success → sent."""
+
+    async def test_failed_retryable_retries_and_succeeds(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        store.mark_turn_publish_failed(
+            session_id,
+            turn_record.turn_uuid,
+            "previous error",
+            retryable=True,
+            attempt_publisher="bot",
+        )
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                status=200,
+                payload={"id": "msg-retry"},
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id == "msg-retry"
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "sent"
+        )
+
+
+class TestT5Nonce:
+    """Acceptance criteria: nonce deterministic and ≤ 25 chars."""
+
+    async def test_nonce_length_and_state(
+        self,
+        publisher: DiscordPublisher,
+        store: SessionStore,
+        session_id: str,
+        turn_record: TurnRecord,
+    ) -> None:
+        store.append_turn(session_id, turn_record)
+        nonce = store.generate_nonce(
+            session_id, turn_record.turn_uuid, "participant_bot"
+        )
+        assert len(nonce) <= 25
+
+        with aioresponses() as m:
+            m.post(
+                DISCORD_API_URL,
+                status=200,
+                payload={"id": "msg-abc"},
+            )
+            msg_id = await publisher.send_turn(session_id, turn_record)
+        assert msg_id is not None
+        assert (
+            store.get_turn_publish_state(session_id, turn_record.turn_uuid)
+            == "sent"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aioresponses"
+version = "0.7.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -285,6 +298,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aioresponses" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -301,6 +315,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aioresponses", specifier = ">=0.7" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
 ]


### PR DESCRIPTION
Discord HTTP API 메시지 발송 및 publish lifecycle 상태 전이 관리\n\nCloses #6